### PR TITLE
Use custom alert component instead of browser popups

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react'
+import Alert from './components/Alert'
 
 const API_BASE = import.meta.env.VITE_API_BASE || 'http://localhost:8000'
 
@@ -19,6 +20,9 @@ export default function App() {
   const [routerUsername, setRouterUsername] = useState('admin')
   const [routerPassword, setRouterPassword] = useState('admin')
   const [networkLoading, setNetworkLoading] = useState(false)
+  const [alert, setAlert] = useState(null)
+
+  const showAlert = (message, type = 'info') => setAlert({ message, type })
 
   const fetchPorts = async () => {
     const res = await fetch(`${API_BASE}/ports`)
@@ -63,7 +67,7 @@ export default function App() {
     })
     if (!res.ok) {
       const err = await res.json().catch(() => ({}))
-      alert(`Attach failed: ${err.detail || res.status}`)
+      showAlert(`Attach failed: ${err.detail || res.status}`, 'error')
       return
     }
     setAttached(true)
@@ -140,7 +144,7 @@ export default function App() {
 
   const networkDisconnect = async () => {
     if (!macAddress.trim()) {
-      alert('Please enter MAC address')
+      showAlert('Please enter MAC address', 'error')
       return
     }
     
@@ -159,15 +163,15 @@ export default function App() {
       
       if (!res.ok) {
         const err = await res.json().catch(() => ({}))
-        alert(`Network disconnect failed: ${err.detail || res.status}`)
+        showAlert(`Network disconnect failed: ${err.detail || res.status}`, 'error')
         return
       }
       
       const result = await res.json()
       setNetworkConnected(false)
-      alert('ESP32 network disconnected successfully')
+      showAlert('ESP32 network disconnected successfully', 'success')
     } catch (error) {
-      alert(`Network disconnect error: ${error.message}`)
+      showAlert(`Network disconnect error: ${error.message}`, 'error')
     } finally {
       setNetworkLoading(false)
     }
@@ -175,7 +179,7 @@ export default function App() {
 
   const networkConnect = async () => {
     if (!macAddress.trim()) {
-      alert('Please enter MAC address')
+      showAlert('Please enter MAC address', 'error')
       return
     }
     
@@ -194,15 +198,15 @@ export default function App() {
       
       if (!res.ok) {
         const err = await res.json().catch(() => ({}))
-        alert(`Network connect failed: ${err.detail || res.status}`)
+        showAlert(`Network connect failed: ${err.detail || res.status}`, 'error')
         return
       }
       
       const result = await res.json()
       setNetworkConnected(true)
-      alert('ESP32 network connected successfully')
+      showAlert('ESP32 network connected successfully', 'success')
     } catch (error) {
-      alert(`Network connect error: ${error.message}`)
+      showAlert(`Network connect error: ${error.message}`, 'error')
     } finally {
       setNetworkLoading(false)
     }
@@ -210,6 +214,7 @@ export default function App() {
 
   return (
     <div className="min-h-full w-full bg-gray-50 text-gray-900">
+      <Alert message={alert?.message} type={alert?.type} onClose={() => setAlert(null)} />
       <header className="border-b bg-white">
         <div className="max-w-6xl mx-auto px-4 py-4 flex items-center justify-between">
           <h1 className="text-xl font-bold">ESP Serial Web Monitor</h1>

--- a/frontend/src/components/Alert.jsx
+++ b/frontend/src/components/Alert.jsx
@@ -1,0 +1,27 @@
+import React, { useEffect } from 'react'
+
+export default function Alert({ message, type = 'info', onClose }) {
+  useEffect(() => {
+    if (!message) return
+    const t = setTimeout(() => {
+      onClose && onClose()
+    }, 5000)
+    return () => clearTimeout(t)
+  }, [message, onClose])
+
+  if (!message) return null
+
+  const baseClasses = 'fixed top-4 right-4 z-50 px-4 py-3 rounded-xl shadow border flex items-start gap-2'
+  let colorClasses = 'bg-blue-100 border-blue-200 text-blue-800'
+  if (type === 'error') colorClasses = 'bg-red-100 border-red-200 text-red-800'
+  if (type === 'success') colorClasses = 'bg-green-100 border-green-200 text-green-800'
+
+  return (
+    <div className={`${baseClasses} ${colorClasses}`}>
+      <span className="flex-1">{message}</span>
+      <button className="ml-2" onClick={onClose} aria-label="Close">
+        &times;
+      </button>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add reusable Alert component with success/error styles
- replace `alert()` calls in App with component-driven notifications

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689df8e53fc08333b98d1159e8500c1d