### PR TITLE
feat: add project path flashing

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,7 @@
 import asyncio
 import httpx
+import os
+import subprocess
 
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
@@ -16,6 +18,13 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
     allow_credentials=True,
+)
+
+# Path to the PlatformIO CLI. This defaults to the user's Windows installation path
+# but can be overridden via the PIO_CMD environment variable.
+PIO_CMD = os.getenv(
+    "PIO_CMD",
+    r"C:\Users\Naufal Reky Ardhana\.platformio\penv\Scripts\pio",
 )
 
 serial_mgr = SerialManager()
@@ -103,6 +112,10 @@ class WriteReq(BaseModel):
     data: str
     newline: bool = True
 
+
+class FlashReq(BaseModel):
+    project_path: str
+
 class NetworkControlReq(BaseModel):
     mac_address: str = Field(..., description="ESP32 MAC address to block/unblock")
     router_host: str = Field(default="192.168.1.1", description="Router IP address")
@@ -146,6 +159,25 @@ def write(req: WriteReq):
         return {"ok": True}
     except RuntimeError as e:
         raise HTTPException(status_code=400, detail=str(e))
+
+
+@app.post("/flash")
+def flash(req: FlashReq):
+    """Flash firmware using PlatformIO."""
+    if not os.path.isdir(req.project_path):
+        raise HTTPException(status_code=404, detail="Project path not found")
+    try:
+        result = subprocess.run(
+            [PIO_CMD, "run", "-t", "upload", "-e", "arduino_nano_esp32"],
+            cwd=req.project_path,
+            capture_output=True,
+            text=True,
+        )
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+    if result.returncode != 0:
+        raise HTTPException(status_code=400, detail=result.stderr.strip() or "Flash failed")
+    return {"ok": True, "output": result.stdout}
 
 @app.post("/network/disconnect")
 async def network_disconnect(req: NetworkControlReq):

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -20,6 +20,8 @@ export default function App() {
   const [routerUsername, setRouterUsername] = useState('admin')
   const [routerPassword, setRouterPassword] = useState('admin')
   const [networkLoading, setNetworkLoading] = useState(false)
+  const [projectPath, setProjectPath] = useState('')
+  const [flashLoading, setFlashLoading] = useState(false)
   const [alert, setAlert] = useState(null)
 
   const showAlert = (message, type = 'info') => setAlert({ message, type })
@@ -218,6 +220,31 @@ export default function App() {
     }
   }
 
+  const flashFirmware = async () => {
+    if (!projectPath.trim()) {
+      showAlert('Please enter project path', 'error')
+      return
+    }
+    setFlashLoading(true)
+    try {
+      const res = await fetch(`${API_BASE}/flash`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ project_path: projectPath })
+      })
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}))
+        showAlert(`Flash failed: ${err.detail || res.status}`, 'error')
+      } else {
+        showAlert('Flash successful', 'success')
+      }
+    } catch (error) {
+      showAlert(`Flash error: ${error.message}`, 'error')
+    } finally {
+      setFlashLoading(false)
+    }
+  }
+
   const sortedPorts = React.useMemo(() => {
     const re = /USB[\s-]*SERIAL/i;
     return [...ports].sort((a, b) => {
@@ -259,6 +286,32 @@ export default function App() {
       </header>
 
       <main className="max-w-6xl mx-auto px-4 py-6 space-y-6">
+        {/* Flash Firmware Section */}
+        <section className="bg-white p-4 rounded-2xl shadow">
+          <h2 className="text-lg font-semibold mb-4">Flash Firmware</h2>
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-4 items-end">
+            <div className="md:col-span-3">
+              <label className="block text-sm font-medium mb-1">Project Path</label>
+              <input
+                type="text"
+                className="w-full rounded-xl border-gray-300"
+                value={projectPath}
+                onChange={e => setProjectPath(e.target.value)}
+                placeholder="Path to PlatformIO project"
+              />
+            </div>
+            <div>
+              <button
+                className="w-full rounded-xl bg-purple-600 text-white px-4 py-2 font-medium shadow hover:bg-purple-700 disabled:opacity-50"
+                onClick={flashFirmware}
+                disabled={flashLoading}
+              >
+                {flashLoading ? 'Flashing...' : 'Flash'}
+              </button>
+            </div>
+          </div>
+        </section>
+
         {/* Network Control Section */}
         <section className="bg-white p-4 rounded-2xl shadow">
           <h2 className="text-lg font-semibold mb-4">Network Control : MiFi Advan</h2>


### PR DESCRIPTION
## Summary
- add backend endpoint to flash firmware using PlatformIO at a user supplied project path
- expose UI controls for firmware flashing and project path input

## Testing
- `python -m py_compile backend/app/main.py`
- `cd frontend && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a54de7ed1c8333afb6c92c211c8972