### PR TITLE
feat: display streaming PlatformIO flash output

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,10 +1,10 @@
 import asyncio
 import httpx
 import os
-import subprocess
 
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 
 from .serial_manager import SerialManager
@@ -162,23 +162,38 @@ def write(req: WriteReq):
 
 
 @app.post("/flash")
-def flash(req: FlashReq):
-    """Flash firmware using PlatformIO."""
+async def flash(req: FlashReq):
+    """Flash firmware using PlatformIO and stream the output."""
     req.project_path = req.project_path.replace("\\", "/")
     if not os.path.isdir(req.project_path):
         raise HTTPException(status_code=404, detail="Project path not found")
+
     try:
-        result = subprocess.run(
-            [PIO_CMD, "run", "-t", "upload", "-e", "arduino_nano_esp32"],
+        proc = await asyncio.create_subprocess_exec(
+            PIO_CMD,
+            "run",
+            "-t",
+            "upload",
+            "-e",
+            "arduino_nano_esp32",
             cwd=req.project_path,
-            capture_output=True,
-            text=True,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
         )
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
-    if result.returncode != 0:
-        raise HTTPException(status_code=400, detail=result.stderr.strip() or "Flash failed")
-    return {"ok": True, "output": result.stdout}
+
+    async def stream():
+        try:
+            while True:
+                line = await proc.stdout.readline()
+                if not line:
+                    break
+                yield line.decode()
+        finally:
+            await proc.wait()
+
+    return StreamingResponse(stream(), media_type="text/plain")
 
 @app.post("/network/disconnect")
 async def network_disconnect(req: NetworkControlReq):

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -22,6 +22,7 @@ export default function App() {
   const [networkLoading, setNetworkLoading] = useState(false)
   const [projectPath, setProjectPath] = useState('C:\\Users\\Naufal Reky Ardhana\\CLionProjects\\diawan-iot-boilerplate')
   const [flashLoading, setFlashLoading] = useState(false)
+  const [flashOutput, setFlashOutput] = useState('')
   const [alert, setAlert] = useState(null)
 
   const showAlert = (message, type = 'info') => setAlert({ message, type })
@@ -226,20 +227,39 @@ export default function App() {
       return
     }
     setFlashLoading(true)
+    setFlashOutput('')
     try {
       const res = await fetch(`${API_BASE}/flash`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ project_path: projectPath })
       })
+
       if (!res.ok) {
-        const err = await res.json().catch(() => ({}))
-        showAlert(`Flash failed: ${err.detail || res.status}`, 'error')
-      } else {
-        showAlert('Flash successful', 'success')
+        const data = await res.json().catch(() => ({}))
+        showAlert(`Flash failed: ${data.detail || res.status}`, 'error')
+        setFlashOutput(data.detail || '')
+        return
       }
+
+      if (!res.body) {
+        showAlert('Flash failed: no response body', 'error')
+        return
+      }
+
+      const reader = res.body.getReader()
+      const decoder = new TextDecoder()
+      while (true) {
+        const { value, done } = await reader.read()
+        if (done) break
+        const chunk = decoder.decode(value, { stream: true })
+        setFlashOutput(prev => prev + chunk)
+      }
+
+      showAlert('Flash complete', 'success')
     } catch (error) {
       showAlert(`Flash error: ${error.message}`, 'error')
+      setFlashOutput(error.message)
     } finally {
       setFlashLoading(false)
     }
@@ -310,6 +330,12 @@ export default function App() {
               </button>
             </div>
           </div>
+          {flashOutput && (
+            <div className="mt-4">
+              <h3 className="text-sm font-medium mb-1">PlatformIO Output</h3>
+              <pre className="bg-gray-100 p-2 rounded-xl text-xs overflow-auto max-h-48 whitespace-pre-wrap">{flashOutput}</pre>
+            </div>
+          )}
         </section>
 
         {/* Network Control Section */}


### PR DESCRIPTION
## Summary
- stream PlatformIO flashing output from the backend
- read and render flashing output incrementally on the frontend

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a55ab0b4608333998b62ba32782755