### PR TITLE
Add MQTT payload chart

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,8 +9,10 @@
       "version": "0.0.1",
       "dependencies": {
         "@vitejs/plugin-react": "^4.7.0",
+        "chart.js": "^4.5.0",
         "class-variance-authority": "^0.7.0",
         "react": "^18.3.1",
+        "react-chartjs-2": "^5.3.0",
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
@@ -741,6 +743,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1347,6 +1355,18 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
     },
     "node_modules/chokidar": {
       "version": "3.6.0",
@@ -2306,6 +2326,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-chartjs-2": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.0.tgz",
+      "integrity": "sha512-UfZZFnDsERI3c3CZGxzvNJd02SHjaSJ8kgW1djn65H1KK8rehwTjyrRKOG3VTMG8wtHZ5rgAO5oTHtHi9GCCmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-dom": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,8 +10,10 @@
   },
   "dependencies": {
     "@vitejs/plugin-react": "^4.7.0",
+    "chart.js": "^4.5.0",
     "class-variance-authority": "^0.7.0",
     "react": "^18.3.1",
+    "react-chartjs-2": "^5.3.0",
     "react-dom": "^18.3.1"
   },
   "devDependencies": {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { Alert, AlertDescription } from './components/ui/alert'
+import DataChart from './components/data-chart'
 
 const API_BASE = import.meta.env.VITE_API_BASE || 'http://192.168.0.171:8000'
 
@@ -11,6 +12,9 @@ export default function App() {
   const [log, setLog] = useState([])
   const [sending, setSending] = useState('')
   const wsRef = useRef(null)
+  const [labels, setLabels] = useState([])
+  const [series1, setSeries1] = useState([])
+  const [series2, setSeries2] = useState([])
   
   // Network control state
   const [networkConnected, setNetworkConnected] = useState(true)
@@ -90,13 +94,39 @@ export default function App() {
     ws.onmessage = (e) => {
       try {
         const data = JSON.parse(e.data)
-        const ts = new Date(data.ts * 1000).toLocaleString()
+        const tsDate = new Date(data.ts * 1000)
+        const ts = tsDate.toLocaleString()
         const line = data.line
         setLog(prev => {
           const arr = [...prev, `[${ts}] ${line}`]
           if (arr.length > 5000) arr.shift()
           return arr
         })
+        if (line.includes('Payload:')) {
+          const jsonStr = line.split('Payload:')[1].trim()
+          try {
+            const payload = JSON.parse(jsonStr)
+            if (Array.isArray(payload.data)) {
+              setLabels(prev => {
+                const arr = [...prev, tsDate.toLocaleTimeString()]
+                if (arr.length > 50) arr.shift()
+                return arr
+              })
+              setSeries1(prev => {
+                const arr = [...prev, payload.data[0]]
+                if (arr.length > 50) arr.shift()
+                return arr
+              })
+              setSeries2(prev => {
+                const arr = [...prev, payload.data[1]]
+                if (arr.length > 50) arr.shift()
+                return arr
+              })
+            }
+          } catch {
+            /* ignore */
+          }
+        }
       } catch {
         setLog(prev => {
           const arr = [...prev, e.data]
@@ -438,6 +468,12 @@ export default function App() {
               <button className="rounded-xl border px-3 py-2 shadow-sm" onClick={downloadLog}>Download</button>
             </div>
           </div>
+        </section>
+
+        {/* MQTT Data Chart */}
+        <section className="bg-white p-4 rounded-2xl shadow">
+          <h2 className="text-lg font-semibold mb-4">MQTT Payload Data</h2>
+          <DataChart labels={labels} data1={series1} data2={series2} />
         </section>
 
         <section className="bg-white p-4 rounded-2xl shadow">

--- a/frontend/src/components/data-chart.jsx
+++ b/frontend/src/components/data-chart.jsx
@@ -1,0 +1,48 @@
+import React from 'react'
+import { Line } from 'react-chartjs-2'
+import {
+  Chart as ChartJS,
+  LineElement,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  Legend,
+  Tooltip
+} from 'chart.js'
+
+ChartJS.register(LineElement, CategoryScale, LinearScale, PointElement, Legend, Tooltip)
+
+export default function DataChart({ labels, data1, data2 }) {
+  const data = {
+    labels,
+    datasets: [
+      {
+        label: 'Value 1',
+        data: data1,
+        borderColor: 'rgb(75, 192, 192)',
+        tension: 0.1,
+      },
+      {
+        label: 'Value 2',
+        data: data2,
+        borderColor: 'rgb(255, 99, 132)',
+        tension: 0.1,
+      }
+    ]
+  }
+  const options = {
+    responsive: true,
+    maintainAspectRatio: false,
+    animation: false,
+    scales: {
+      x: {
+        ticks: { maxTicksLimit: 10 }
+      }
+    }
+  }
+  return (
+    <div className="h-64">
+      <Line data={data} options={options} />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- visualize MQTT payload data using Chart.js
- parse serial messages for Payload entries and feed chart
- include chart.js and react-chartjs-2 dependencies

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`
- `python -m py_compile backend/app/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68a56ce75d488333b58fe84dca9ec6dc