### PR TITLE
feat: add ESP32 reset functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ VITE_API_BASE=http://localhost:8000 npm run dev
 - `POST /attach` → body `{ "port": "/dev/ttyUSB0", "baudrate": 115200 }`
 - `POST /detach` → `{ ok: true }`
 - `POST /write` → body `{ "data": "AT+GMR", "newline": true }`
+- `POST /reset` → `{ ok: true }` (resets the attached ESP32)
 - `POST /network/connect` → body `{ "mac_address": "AA:BB:CC:DD:EE:FF", "router_host": "192.168.1.1", "username": "admin", "password": "admin" }`
 - `POST /network/disconnect` → body `{ "mac_address": "AA:BB:CC:DD:EE:FF", "router_host": "192.168.1.1", "username": "admin", "password": "admin" }`
 - `WS /ws/serial` → JSON messages `{ "ts": <unix seconds>, "line": "..." }`

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -149,6 +149,16 @@ def detach():
     serial_mgr.detach()
     return {"ok": True}
 
+@app.post("/reset")
+def reset():
+    if not serial_mgr.is_attached():
+        raise HTTPException(status_code=409, detail="Serial not attached")
+    try:
+        serial_mgr.reset()
+        return {"ok": True}
+    except RuntimeError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
 @app.post("/write")
 def write(req: WriteReq):
     if not serial_mgr.is_attached():

--- a/backend/app/serial_manager.py
+++ b/backend/app/serial_manager.py
@@ -85,6 +85,21 @@ class SerialManager:
             except SerialException as e:
                 raise RuntimeError(f"Failed to write to serial: {e}")
 
+    def reset(self) -> None:
+        """Toggle DTR/RTS lines to reset the connected ESP32."""
+        with self._lock:
+            if not self.is_attached():
+                raise RuntimeError("Serial is not attached")
+            try:
+                # Typical ESP32 reset via serial control lines
+                self._ser.setDTR(False)
+                self._ser.setRTS(True)
+                time.sleep(0.1)
+                self._ser.setDTR(True)
+                self._ser.setRTS(False)
+            except SerialException as e:
+                raise RuntimeError(f"Failed to reset device: {e}")
+
     def register_client(self) -> asyncio.Queue:
         q: asyncio.Queue = asyncio.Queue(maxsize=2000)
         self._clients.add(q)

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -153,6 +153,17 @@ export default function App() {
     }
   }
 
+  const reset = async () => {
+    if (!attached) return
+    const res = await fetch(`${API_BASE}/reset`, { method: 'POST' })
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}))
+      showAlert(`Reset failed: ${err.detail || res.status}`, 'error')
+      return
+    }
+    showAlert('ESP32 reset successfully', 'success')
+  }
+
   const clearLog = () => setLog([])
 
   const downloadLog = () => {
@@ -461,6 +472,13 @@ export default function App() {
                 disabled={attached}
               >
                 Refresh Ports
+              </button>
+              <button
+                className="rounded-xl bg-red-600 text-white px-4 py-2 font-medium shadow hover:bg-red-700"
+                onClick={reset}
+                disabled={!attached}
+              >
+                Reset
               </button>
             </div>
             <div className="flex gap-2 justify-end">


### PR DESCRIPTION
## Summary
- add SerialManager.reset to toggle DTR/RTS for ESP32 reset
- expose new POST `/reset` endpoint
- add frontend button to trigger reset
- document reset API in README

## Testing
- `python -m py_compile backend/app/serial_manager.py backend/app/main.py`
- `cd frontend && npm test >/tmp/npm-test.log && cat /tmp/npm-test.log` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a56f5ae3188333a6675e13793a4afe